### PR TITLE
Add more Dart/IntelliJ patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,30 @@
-main.dart
-main2.dart
-packages/
+# See https://github.com/matanlurey/gitignore
+
+# Files and directories created by pub
+.buildlog
 .packages
+.project
+.pub
+**/build
+**/packages
+
+# Files created by dart2js
+# (Most Dart developers will use pub build to compile Dart, use/modify these
+#  rules if you intend to use dart2js directly
+#  Convention is to use extension '.dart.js' for Dart compiled to Javascript to
+#  differentiate from explicit Javascript files)
+*.dart.js
+*.part.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/api/
+
+# Don't commit pubspec lock file
+# (Library packages only! Remove pattern if developing an application package)
 pubspec.lock
-doc/
-.pub/
-test/packages
-example/packages
-pm2.json
-.atom
+
+*.iml
+.idea


### PR DESCRIPTION
Auto-generated by the [gitignore](https://github.com/matanlurey/gitignore) package.