### PR TITLE
Fix increasing number of heartbeats

### DIFF
--- a/lib/src/objects/Shard.dart
+++ b/lib/src/objects/Shard.dart
@@ -51,7 +51,6 @@ class Shard extends _BaseObj {
   /// Sends a heartbeat packet.
   void _heartbeat() {
     this._send("HEARTBEAT", _sequence);
-    new Timer(_heartbeatInterval, _heartbeat);
   }
 
   Future<Null> _handleMsg(String msg, bool resume) async {


### PR DESCRIPTION
A new timer is created on every call to _heartbeat (line 54), but the initial timer on line 88 is already repeating (periodic).
This causes an increasing number of heartbeats to be sent every time - first 1, then 2 at the same time, 3 at the same time, etc.

This is what it looks like with some logging added:
> 00:31:29.312696 - sending heartbeat
>
> 00:32:10.556355 - sending heartbeat
> 00:32:10.564373 - sending heartbeat
>
> 00:32:51.806284 - sending heartbeat
> 00:32:51.807203 - sending heartbeat
> 00:32:51.815339 - sending heartbeat
>
> 00:33:33.056295 - sending heartbeat
> 00:33:33.057198 - sending heartbeat
> 00:33:33.058201 - sending heartbeat
> 00:33:33.066252 - sending heartbeat
>
> 00:34:14.306295 - sending heartbeat
> 00:34:14.307213 - sending heartbeat
> 00:34:14.308197 - sending heartbeat
> 00:34:14.309201 - sending heartbeat
> 00:34:14.317346 - sending heartbeat
>
> 00:34:55.556343 - sending heartbeat
> 00:34:55.557282 - sending heartbeat
> 00:34:55.558252 - sending heartbeat
> 00:34:55.559393 - sending heartbeat
> 00:34:55.560209 - sending heartbeat
> 00:34:55.568282 - sending heartbeat

After about 45 minutes, Discord drops the connection for ratelimiting :grin:

I'm not completely sure if line 54 should be removed, or if 88 should be changed to be non-periodic instead. Feel free to drop this PR and do that instead if it fits better :+1: 