### PR TITLE
Change typing event channel to any type of channel

### DIFF
--- a/lib/src/main/events/TypingEvent.dart
+++ b/lib/src/main/events/TypingEvent.dart
@@ -3,7 +3,7 @@ part of discord;
 /// Sent when a user starts typing.
 class TypingEvent {
   /// The channel that the user is typing in.
-  GuildChannel channel;
+  Channel channel;
 
   /// The user that is typing.
   User user;


### PR DESCRIPTION
Fixes an error when the typing event is fired on a DM channel the second time because the channel is of the class GuildChannel